### PR TITLE
Optional client oauth

### DIFF
--- a/lib/ClientBase.js
+++ b/lib/ClientBase.js
@@ -46,10 +46,11 @@ function ClientBase(opts) {
   }, opts);
 
   // check for the different auth strategies
-  var api = this.apiKey && this.apiSecret;
+  var api = !!(this.apiKey && this.apiSecret)
   var oauth = !!this.accessToken;
 
-  if (!oauth && !api) {
+  // XOR
+  if (!(api ^ oauth)) {
     throw new Error('you must either provide an "accessToken" or the "apiKey" & "apiSecret" parameters');
   }
 }

--- a/lib/ClientBase.js
+++ b/lib/ClientBase.js
@@ -38,18 +38,19 @@ function ClientBase(opts) {
   if (!(this instanceof ClientBase)) {
     return new ClientBase(opts);
   }
-  assign(this, opts);
-  if (!this.apiKey) {
-    throw new Error("no apiKey");
-  }
-  if (!this.apiSecret) {
-    throw new Error("no apiSecret");
-  }
-  if (!this.baseApiUri) {
-    this.baseApiUri = BASE_URI;
-  }
-  if (!this.tokenUri) {
-    this.tokenUri = TOKEN_ENDPOINT_URI;
+
+  // assign defaults and options to the context
+  assign(this, {
+    baseApiUri: BASE_URI,
+    tokenUri: TOKEN_ENDPOINT_URI
+  }, opts);
+
+  // check for the different auth strategies
+  var api = this.apiKey && this.apiSecret;
+  var oauth = !!this.accessToken;
+
+  if (!oauth && !api) {
+    throw new Error('you must either provide an "accessToken" or the "apiKey" & "apiSecret" parameters');
   }
 }
 
@@ -77,53 +78,51 @@ ClientBase.prototype._setAccessTokenOrExpire = function (url) {
 };
 
 ClientBase.prototype._generateSignature = function (url, bodyStr) {
-
   var nonce     = String(new Date().getTime()) + new Date().getMilliseconds();
   var message   = String(nonce) + url + bodyStr;
-  var signature = crypto.createHmac("sha256",
-
-  this.apiSecret).update(message).digest("hex");
-
+  var signature = crypto.createHmac("sha256", this.apiSecret).update(message).digest("hex");
   return {"nonce": nonce, "digest": signature};
 };
 
 ClientBase.prototype._generateReqOptions = function (url, body, method, headers) {
 
-  var bodyStr = !body
-    ? ''
-    : JSON.stringify(body);
-  var sig = this._generateSignature(url, bodyStr);
+  var bodyStr = body ? JSON.stringify(body) : '';
 
+  // specify the options
   var options = {
     "url": url,
+    "body": bodyStr,
     "method": method,
     "headers" : {
       'Content-Type'     : 'application/json',
       'Accept'           : 'application/json',
-      'User-Agent'       : 'coinbase/node/1.0',
-      "ACCESS_SIGNATURE" : sig.digest,
-      "ACCESS_NONCE"     : sig.nonce
-    },
-    "body"         : bodyStr
+      'User-Agent'       : 'coinbase/node/1.0'
+    }
   };
-  if (!this.accessToken) {options.headers.ACCESS_KEY = this.apiKey;}
 
-  if (headers) {assign(options.headers, headers);}
+  // add additional headers when we're using the "api key" and "api secret"
+  if (this.apiSecret && this.apiKey) {
+    var sig = this._generateSignature(url, bodyStr);
+
+    // add signature and nonce to the header
+    options.headers = assign(options.headers, {
+      'ACCESS_SIGNATURE': sig.digest,
+      'ACCESS_NONCE': sig.nonce,
+      'ACCESS_KEY': this.apiKey
+    })
+  }
 
   return options;
 };
 
 ClientBase.prototype._getHttp = function (path, args, callback, headers) {
 
-  var params = !args
-    ? ''
-    :  '?' + qs.stringify(args);
-
+  var params = args ? '?' + qs.stringify(args) : '';
   var url = this._setAccessTokenOrExpire(this.baseApiUri + path + params);
+  var opts = this._generateReqOptions(url, null, 'GET', headers);
 
   request.get(
-    url,
-    this._generateReqOptions(url, null, 'GET', headers),
+    opts,
     function onGet(err, response, body) {
       if (!handleHttpError(err, response, callback)) {
         if (!body) {
@@ -281,4 +280,3 @@ ClientBase.prototype._postOneHttp = function (opts, callback, headers) {
 };
 
 module.exports = ClientBase;
-

--- a/test/testClient.js
+++ b/test/testClient.js
@@ -33,8 +33,28 @@ describe('Client', function() {
       assert(false);
     });
 
+    it('should work support oauth', function() {
+      var cl1 = Client({ accessToken: 'mytoken', 'baseApiUri': na.TEST_BASE_URI })
+      assert.equal(cl1.accessToken, 'mytoken');
+      assert(cl1 instanceof Client);
+    })
+
+    it('should support an optional refresh token', function() {
+      var cl1 = Client({ accessToken: 'mytoken', refreshToken: 'refreshtoken', 'baseApiUri': na.TEST_BASE_URI })
+      assert.equal(cl1.accessToken, 'mytoken');
+      assert.equal(cl1.refreshToken, 'refreshtoken');
+      assert(cl1 instanceof Client);
+    })
+
+    it('should throw if the we do not pass the access token or api credentials', function() {
+      try {
+        Client({ 'baseApiUri': na.TEST_BASE_URI })
+      } catch (e) {
+        assert.equal(e.message, 'you must either provide an "accessToken" or the "apiKey" & "apiSecret" parameters')
+      }
+    })
   });
-  
+
   describe('client methods', function() {
 
     var client = new Client({'apiKey': 'mykey', 'apiSecret': 'mysecret', 'baseApiUri': na.TEST_BASE_URI});
@@ -43,9 +63,9 @@ describe('Client', function() {
         assert.equal(err, null, err);
         assert(accounts, "no accounts");
         assert.equal(accounts.length, 2, "wrong number of accounts");
-        assert.equal(accounts[0].id, na.ACCOUNTS_ID_1, 
+        assert.equal(accounts[0].id, na.ACCOUNTS_ID_1,
           "wrong account id: " + accounts[0].id);
-        assert.equal(accounts[1].id, na.ACCOUNTS_ID_2, 
+        assert.equal(accounts[1].id, na.ACCOUNTS_ID_2,
           "wrong account id: " + accounts[1].id);
       });
     });
@@ -75,7 +95,7 @@ describe('Client', function() {
         assert.equal(err, null, err);
         assert(contacts, 'no contacts');
         assert(contacts[0].email, "no email");
-        assert.equal(contacts[0].email, 
+        assert.equal(contacts[0].email,
           na.GET_CONTACTS_RESP.contacts[0].contact.email,
           'wrong contacts: ' + contacts[0].email);
       });
@@ -86,7 +106,7 @@ describe('Client', function() {
         assert.equal(err, null, err);
         assert(user, 'no user');
         assert(user.name, "no email");
-        assert.equal(user.name, 
+        assert.equal(user.name,
           na.GET_CURRENT_USER_RESP.user.name,
           'wrong user: ' + user.name);
 
@@ -178,14 +198,13 @@ describe('Client', function() {
     });
 
     it('should get payment method', function() {
-      client.getPaymentMethod(na.GET_PAYMENT_METHOD_RESP.payment_method.id, 
+      client.getPaymentMethod(na.GET_PAYMENT_METHOD_RESP.payment_method.id,
         function(err, pm) {
         assert.equal(err, null, err);
         assert(pm, 'no payment method');
-        assert.equal(pm.id, na.GET_PAYMENT_METHOD_RESP.payment_method.id, 
+        assert.equal(pm.id, na.GET_PAYMENT_METHOD_RESP.payment_method.id,
           'wrong payment method');
       });
     });
   });
 });
-

--- a/test/testClient.js
+++ b/test/testClient.js
@@ -49,6 +49,16 @@ describe('Client', function() {
     it('should throw if the we do not pass the access token or api credentials', function() {
       try {
         Client({ 'baseApiUri': na.TEST_BASE_URI })
+        throw new Error('failed');
+      } catch (e) {
+        assert.equal(e.message, 'you must either provide an "accessToken" or the "apiKey" & "apiSecret" parameters')
+      }
+    })
+
+    it('should throw if both the api key + secret and the access token is used', function() {
+      try {
+        Client({ 'accessToken': 'mytoken', 'apiKey': 'mykey', 'apiSecret': 'mysecret' })
+        throw new Error('failed');
       } catch (e) {
         assert.equal(e.message, 'you must either provide an "accessToken" or the "apiKey" & "apiSecret" parameters')
       }


### PR DESCRIPTION
This PR allows the client to support either api key + secret or the oauth access token.

I also updated it so that you can only use one or the other, so it's immediately clear what credentials you are using. Can remove it if there's a use case for having both.