### PR TITLE
Remove account arg from comment on Checkout constructor

### DIFF
--- a/lib/model/Checkout.js
+++ b/lib/model/Checkout.js
@@ -6,11 +6,11 @@ var BaseModel   = require('./BaseModel'),
 
 // ##CONSTRUCTOR
 //
-// _args `client`, `data`, and `account` required_
+// _args `client` and `data` required_
 //
 //```
 // var Checkout = require('coinbase').model.Checkout;
-// var myCheckout = new Checkout(client, data, account);
+// var myCheckout = new Checkout(client, data);
 //```
 function Checkout(client, data) {
   if (!(this instanceof Checkout)) {


### PR DESCRIPTION
Remove the `account` arg from the comment on the Checkout constructor. It isn't used in the constructor.