### PR TITLE
Reference new signature header in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ client.getBuyPrice({'currency': 'USD'}, function(err, obj) {
 
 **Verifying merchant callback authenticity**
 ```javascript
-if (client.verifyCallback(req.raw_body, req.headers['X-Signature'])) {
+if (client.verifyCallback(req.raw_body, req.headers['CB-SIGNATURE'])) {
   // Process callback
 }
 ```


### PR DESCRIPTION
We've now backported the CB-SIGNATURE header to v1 so we can just reference CB-SIGNATURE everywhere.

Ref #53
