### PR TITLE
Handle non-json HTTP errors

### DIFF
--- a/lib/errorHandler.js
+++ b/lib/errorHandler.js
@@ -40,10 +40,15 @@ function handleHttpError(err, response, callback) {
   if (response.statusCode !== 200 &&
       response.statusCode !== 201 &&
       response.statusCode !== 204) {
-    var errorBody = _parseError(JSON.parse(response.body));
-    var error = createError(response.statusCode,
-                            errorBody.message,
-                            {name: _convertErrorName(errorBody.id)});
+    var error;
+    try {
+      var errorBody = _parseError(JSON.parse(response.body));
+      error = createError(response.statusCode,
+                          errorBody.message,
+                          {name: _convertErrorName(errorBody.id)});
+    } catch (ex) {
+      error = createError(response.statusCode, response.body);
+    }
     callback(error, null);
     return true;
   }


### PR DESCRIPTION
If `handleHttpError` receives a non-JSON body in an error, the method will crash with an uncaught exception.

This PR catches that exception and gracefully passes the error on with the raw error message.

Covers #56 and fixes #55 