### PR TITLE
Add parameters to path when generating signature

### DIFF
--- a/lib/ClientBase.js
+++ b/lib/ClientBase.js
@@ -149,7 +149,7 @@ ClientBase.prototype._getHttp = function(path, args, callback, headers) {
   }
 
   var url = this.baseApiUri + this._setAccessToken(path + params);
-  var opts = this._generateReqOptions(url, path, null, 'GET', headers);
+  var opts = this._generateReqOptions(url, path + params, null, 'GET', headers);
 
   request.get(opts, function onGet(err, response, body) {
     if (!handleHttpError(err, response, callback)) {


### PR DESCRIPTION
When using an API key/secret, parameters weren't included in the signature, which caused pagination to fail.  This should fix that.
