### PR TITLE
Includes optional paramters in getSpotPrice, fixes issue #73.

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -143,15 +143,19 @@ Client.prototype.getSellPrice = function(params, callback) {
 
 Client.prototype.getSpotPrice = function(params, callback) {
 
-  var currencyPair;
+  var opts, currencyPair;
   if (params.currencyPair) {
     currencyPair = params.currencyPair;
+    delete params.currencyPair;
   } else if (params.currency) {
     currencyPair = 'BTC-' + params.currency;
+    delete params.currency;
   } else {
     currencyPair = 'BTC-USD';
   }
-  this._getOneHttp({'path': 'prices/' + currencyPair + '/spot'}, callback);
+  opts = {'path': 'prices/' + currencyPair + '/spot', 'params': params};
+
+  this._getOneHttp(opts, callback);
 };
 
 // deprecated. use getSpotPrice with ?date=YYYY-MM-DD


### PR DESCRIPTION
Fixes bug in Client.prototype.getSpotPrice by including optional paramters the user supplies such as 'date', for example.