### PR TITLE
Fix refresh method

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -36,7 +36,7 @@ Client.prototype.refresh = function(callback) {
   this._postHttp(path, params, function myPost(err, result) {
 
     if (err) {
-      err.type = etypes.TokenRefreshError;
+      err.name = 'TokenRefreshError';
       callback(err, result);
       return;
     }

--- a/lib/ClientBase.js
+++ b/lib/ClientBase.js
@@ -167,8 +167,7 @@ ClientBase.prototype._getHttp = function(path, args, callback, headers) {
 };
 
 ClientBase.prototype._postHttp = function(path, body, callback, headers) {
-
-  var url = this.baseApiUri + this._setAccessToken(path);
+  var url = path === this.tokenUri ? path : this.baseApiUri + this._setAccessToken(path);
   body = body || {}
 
   var options = this._generateReqOptions(url, path, body, 'POST', headers);


### PR DESCRIPTION
This PR fixes a crash when calling the refresh method on the Client to refresh the access/refresh tokens. Closes #72 

It also fixes the url that is used to obtain a new access token. Since previously it would prefix the path with the baseUri and result in an invalid url like this: `https://api.coinbase.com/v2/https://api.coinbase.com/oauth/token?access_token=...`