### PR TITLE
Added Promise support

### DIFF
--- a/lib/Base.js
+++ b/lib/Base.js
@@ -32,5 +32,17 @@ Base.prototype.toString = function() {
   return this.dumpJSON();
 };
 
+Base.prototype._createPromise = function(run, callback) {
+  return new Promise(run)
+    .then(function (result) {
+      if (callback) callback(null, result[0], result[1]);
+      return result;
+    })
+    .catch(function (err) {
+      if (callback) callback(err, null);
+      return err;
+    });
+}
+
 module.exports = Base;
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -53,7 +53,7 @@ Client.prototype.getAccounts = function(args, callback) {
     'ObjFunc'  : Account
   };
 
-  this._getAllHttp(_.assign(args || {}, opts), callback)
+  return this._getAllHttp(_.assign(args || {}, opts), callback)
 };
 
 Client.prototype.getAccount = function(account_id, callback) {
@@ -62,7 +62,7 @@ Client.prototype.getAccount = function(account_id, callback) {
     'path'     : 'accounts/' + account_id,
     'ObjFunc'  : Account
   };
-  this._getOneHttp(opts, callback);
+  return this._getOneHttp(opts, callback);
 };
 
 Client.prototype.createAccount = function(args, callback) {
@@ -73,7 +73,7 @@ Client.prototype.createAccount = function(args, callback) {
     'params'   : args
   };
 
-  this._postOneHttp(opts, callback);
+  return this._postOneHttp(opts, callback);
 };
 
 Client.prototype.getCurrentUser = function(callback) {
@@ -83,7 +83,7 @@ Client.prototype.getCurrentUser = function(callback) {
     'ObjFunc'  : User
   };
 
-  this._getOneHttp(opts, callback);
+  return this._getOneHttp(opts, callback);
 };
 
 Client.prototype.getUser = function(userId, callback) {
@@ -93,7 +93,7 @@ Client.prototype.getUser = function(userId, callback) {
     'ObjFunc'  : User
   };
 
-  this._getOneHttp(opts, callback);
+  return this._getOneHttp(opts, callback);
 };
 
 Client.prototype.getNotifications = function(args, callback) {
@@ -103,7 +103,7 @@ Client.prototype.getNotifications = function(args, callback) {
     'ObjFunc'  : Notification
   };
 
-  this._getAllHttp(_.assign(args || {}, opts), callback)
+  return this._getAllHttp(_.assign(args || {}, opts), callback)
 };
 
 Client.prototype.getNotification = function(notificationId, callback) {
@@ -112,7 +112,7 @@ Client.prototype.getNotification = function(notificationId, callback) {
     'path'     : 'notifications/' + notificationId,
     'ObjFunc'  : Notification
   };
-  this._getOneHttp(opts, callback);
+  return this._getOneHttp(opts, callback);
 };
 
 Client.prototype.getBuyPrice = function(params, callback) {
@@ -125,7 +125,7 @@ Client.prototype.getBuyPrice = function(params, callback) {
   } else {
     currencyPair = 'BTC-USD';
   }
-  this._getOneHttp({'path': 'prices/' + currencyPair + '/buy'}, callback);
+  return this._getOneHttp({'path': 'prices/' + currencyPair + '/buy'}, callback);
 };
 
 Client.prototype.getSellPrice = function(params, callback) {
@@ -138,7 +138,7 @@ Client.prototype.getSellPrice = function(params, callback) {
   } else {
     currencyPair = 'BTC-USD';
   }
-  this._getOneHttp({'path': 'prices/' + currencyPair + '/sell'}, callback);
+  return this._getOneHttp({'path': 'prices/' + currencyPair + '/sell'}, callback);
 };
 
 Client.prototype.getSpotPrice = function(params, callback) {
@@ -155,28 +155,28 @@ Client.prototype.getSpotPrice = function(params, callback) {
   }
   opts = {'path': 'prices/' + currencyPair + '/spot', 'params': params};
 
-  this._getOneHttp(opts, callback);
+  return this._getOneHttp(opts, callback);
 };
 
 // deprecated. use getSpotPrice with ?date=YYYY-MM-DD
 Client.prototype.getHistoricPrices = function(params, callback) {
 
-  this._getOneHttp({'path': 'prices/historic', 'params': params} , callback);
+  return this._getOneHttp({'path': 'prices/historic', 'params': params} , callback);
 };
 
 Client.prototype.getCurrencies = function(callback) {
 
-  this._getOneHttp({'path': 'currencies'}, callback);
+  return this._getOneHttp({'path': 'currencies'}, callback);
 };
 
 Client.prototype.getExchangeRates = function(params, callback) {
 
-  this._getOneHttp({'path': 'exchange-rates', 'params': params}, callback);
+  return this._getOneHttp({'path': 'exchange-rates', 'params': params}, callback);
 };
 
 Client.prototype.getTime = function(callback) {
 
-  this._getOneHttp({'path': 'time'}, callback);
+  return this._getOneHttp({'path': 'time'}, callback);
 };
 
 Client.prototype.getPaymentMethods = function(args, callback) {
@@ -186,7 +186,7 @@ Client.prototype.getPaymentMethods = function(args, callback) {
     'ObjFunc'  : PaymentMethod
   };
 
-  this._getAllHttp(_.assign(args || {}, opts), callback)
+  return this._getAllHttp(_.assign(args || {}, opts), callback)
 };
 
 Client.prototype.getPaymentMethod = function(methodId, callback) {
@@ -196,7 +196,7 @@ Client.prototype.getPaymentMethod = function(methodId, callback) {
     'ObjFunc'  : PaymentMethod
   };
 
-  this._getOneHttp(opts, callback);
+  return this._getOneHttp(opts, callback);
 };
 
 // Merchant Endpoints
@@ -207,7 +207,7 @@ Client.prototype.getOrders = function(args, callback) {
     'ObjFunc'  : Order
   };
 
-  this._getAllHttp(_.assign(args || {}, opts), callback)
+  return this._getAllHttp(_.assign(args || {}, opts), callback)
 };
 
 Client.prototype.getOrder = function(orderId, callback) {
@@ -217,7 +217,7 @@ Client.prototype.getOrder = function(orderId, callback) {
     'ObjFunc'  : Order
   };
 
-  this._getOneHttp(opts, callback);
+  return this._getOneHttp(opts, callback);
 };
 
 Client.prototype.createOrder = function(args, callback) {
@@ -228,7 +228,7 @@ Client.prototype.createOrder = function(args, callback) {
     'params' : args
   };
 
-  this._postOneHttp(opts, callback);
+  return this._postOneHttp(opts, callback);
 };
 
 Client.prototype.getCheckouts = function(args, callback) {
@@ -238,7 +238,7 @@ Client.prototype.getCheckouts = function(args, callback) {
     'ObjFunc'  : Checkout
   };
 
-  this._getAllHttp(_.assign(args || {}, opts), callback)
+  return this._getAllHttp(_.assign(args || {}, opts), callback)
 
 };
 
@@ -249,7 +249,7 @@ Client.prototype.getCheckout = function(checkoutId, callback) {
     'ObjFunc'  : Checkout
   };
 
-  this._getOneHttp(opts, callback);
+  return this._getOneHttp(opts, callback);
 };
 
 Client.prototype.createCheckout = function(args, callback) {
@@ -260,7 +260,7 @@ Client.prototype.createCheckout = function(args, callback) {
     'params' : args
   };
 
-  this._postOneHttp(opts, callback);
+  return this._postOneHttp(opts, callback);
 };
 
 Client.prototype.getMerchant = function(merchantId, callback) {
@@ -270,7 +270,7 @@ Client.prototype.getMerchant = function(merchantId, callback) {
     'ObjFunc' : Merchant
   };
 
-  this._getOneHttp(opts, callback);
+  return this._getOneHttp(opts, callback);
 }
 
 Client.prototype.verifyCallback = function(body, signature) {

--- a/lib/ClientBase.js
+++ b/lib/ClientBase.js
@@ -154,16 +154,18 @@ ClientBase.prototype._getHttp = function(path, args, callback, headers) {
   var url = this.baseApiUri + this._setAccessToken(path + params);
   var opts = this._generateReqOptions(url, path + params, null, 'GET', headers);
 
-  request.get(opts, function onGet(err, response, body) {
-    if (!handleHttpError(err, response, callback)) {
-      if (!body) {
-        callback(new Error("empty response"), null);
-      } else {
-        var obj = JSON.parse(body);
-        callback(null, obj);
+  return this._createPromise(function (resolve, reject) {
+    request.get(opts, function onGet(err, response, body) {
+      if (!handleHttpError(err, response, reject)) {
+        if (!body) {
+          reject(new Error("empty response"))
+        } else {
+          var obj = JSON.parse(body);
+          resolve(obj)
+        }
       }
-    }
-  });
+    });
+  }, callback);
 };
 
 ClientBase.prototype._postHttp = function(path, body, callback, headers) {
@@ -173,16 +175,18 @@ ClientBase.prototype._postHttp = function(path, body, callback, headers) {
 
   var options = this._generateReqOptions(url, path, body, 'POST', headers);
 
-  request.post(options, function onPost(err, response, body) {
-    if (!handleHttpError(err, response, callback)) {
-      if (body) {
-        var obj = JSON.parse(body);
-        callback(null, obj);
-      } else {
-        callback(null, body);
+  return this._createPromise(function (resolve, reject) {
+    request.post(options, function onPost(err, response, body) {
+      if (!handleHttpError(err, response, reject)) {
+        if (body) {
+          var obj = JSON.parse(body);
+          resolve(obj)
+        } else {
+          resolve(body)
+        }
       }
-    }
-  });
+    });
+  }, callback);
 };
 
 ClientBase.prototype._putHttp = function(path, body, callback, headers) {
@@ -191,27 +195,31 @@ ClientBase.prototype._putHttp = function(path, body, callback, headers) {
 
   var options = this._generateReqOptions(url, path, body, 'PUT', headers);
 
-  request.put(options, function onPut(err, response, body) {
-    if (!handleHttpError(err, response, callback)) {
-      if (body) {
-        var obj = JSON.parse(body);
-        callback(null, obj);
-      } else {
-        callback(null, body);
+  return this._createPromise(function (resolve, reject) {
+    request.put(options, function onPut(err, response, body) {
+      if (!handleHttpError(err, response, reject)) {
+        if (body) {
+          var obj = JSON.parse(body);
+          resolve(obj);
+        } else {
+          resolve(body);
+        }
       }
-    }
-  });
+    });
+  }, callback);
 };
 
 
 ClientBase.prototype._deleteHttp = function(path, callback, headers) {
   var url = this.baseApiUri + this._setAccessToken(path);
-  request.del(url, this._generateReqOptions(url, path, null, 'DELETE', headers),
-  function onDel(err, response, body) {
-    if (!handleHttpError(err, response, callback)) {
-      callback(null, body);
-    }
-  });
+  return this._createPromise(function (resolve, reject) {
+    request.del(url, this._generateReqOptions(url, path, null, 'DELETE', headers),
+      function onDel(err, response, body) {
+        if (!handleHttpError(err, response, reject)) {
+          resolve(body);
+        }
+      });
+  }, callback);
 };
 
 //
@@ -248,18 +256,28 @@ ClientBase.prototype._getAllHttp = function(opts, callback, headers) {
     }
   }
 
-  this._getHttp(path, args, function onGet(err, result) {
-    if (!handleError(err, result, callback)) {
-      var objs = [];
-      if (result.data.length !== 0) {
-        var ObjFunc = self._stringToClass(result.data[0].resource);
-        objs = _.map(result.data, function onMap(obj) {
-          return new ObjFunc(self, obj);
-        });
+  return new Promise(function (resolve, reject) {
+    self._getHttp(path, args, function onGet(err, result) {
+      if (!handleError(err, result, reject)) {
+        var objs = [];
+        if (result.data.length !== 0) {
+          var ObjFunc = self._stringToClass(result.data[0].resource);
+          objs = _.map(result.data, function onMap(obj) {
+            return new ObjFunc(self, obj);
+          });
+        }
+        resolve([objs, result.pagination])
       }
-      callback(null, objs, result.pagination);
-    }
-  }, headers);
+    }, headers);
+  })
+    .then(function (result) {
+      if (callback) callback(null, result[0], result[1]);
+      return result;
+    })
+    .catch(function (err) {
+      if (callback) callback(err, null);
+      return err;
+    });
 };
 
 //
@@ -270,16 +288,18 @@ ClientBase.prototype._getAllHttp = function(opts, callback, headers) {
 //
 ClientBase.prototype._getOneHttp = function(args, callback, headers) {
   var self = this;
-  this._getHttp(args.path, args.params, function onGet(err, obj) {
-    if (!handleError(err, obj, callback)) {
-      if (obj.data.resource) {
-        var ObjFunc = self._stringToClass(obj.data.resource);
-        callback(null, new ObjFunc(self, obj.data));
-      } else {
-        callback(null, obj);
+  return this._createPromise(function (resolve, reject) {
+    self._getHttp(args.path, args.params, function onGet(err, obj) {
+      if (!handleError(err, obj, reject)) {
+        if (obj.data.resource) {
+          var ObjFunc = self._stringToClass(obj.data.resource);
+          resolve(new ObjFunc(self, obj.data))
+        } else {
+          resolve(obj)
+        }
       }
-    }
-  }, headers);
+    }, headers);
+  }, callback);
 };
 
 //
@@ -291,20 +311,34 @@ ClientBase.prototype._getOneHttp = function(args, callback, headers) {
 ClientBase.prototype._postOneHttp = function(opts, callback, headers) {
    var self = this;
    var body = opts.params;
-   this._postHttp(opts.colName, body, function onPost(err, obj) {
-    if (!handleError(err, obj, callback)) {
-      if (obj.data.resource) {
-        var ObjFunc = self._stringToClass(obj.data.resource);
-        callback(null, new ObjFunc(self, obj.data));
-      } else {
-        callback(null, obj);
-      }
-    }
-  }, headers);
+   return this._createPromise(function (resolve, reject) {
+     this._postHttp(opts.colName, body, function onPost(err, obj) {
+       if (!handleError(err, obj, reject)) {
+         if (obj.data.resource) {
+           var ObjFunc = self._stringToClass(obj.data.resource);
+           resolve(new ObjFunc(self, obj.data));
+         } else {
+           resolve(obj);
+         }
+       }
+     }, headers);
+   }, callback)
 };
 
 ClientBase.prototype._stringToClass = function(name) {
   return MODELS[name]
 };
+
+ClientBase.prototype._createPromise = function(run, callback) {
+  return new Promise(run)
+    .then(function (obj) {
+      if (callback) callback(null, obj);
+      return [obj];
+    })
+    .catch(function (err) {
+      if (callback) callback(err, null);
+      return err;
+    });
+}
 
 module.exports = ClientBase;

--- a/lib/ClientBase.js
+++ b/lib/ClientBase.js
@@ -161,7 +161,7 @@ ClientBase.prototype._getHttp = function(path, args, callback, headers) {
           reject(new Error("empty response"))
         } else {
           var obj = JSON.parse(body);
-          resolve(obj)
+          resolve([obj])
         }
       }
     });
@@ -180,9 +180,9 @@ ClientBase.prototype._postHttp = function(path, body, callback, headers) {
       if (!handleHttpError(err, response, reject)) {
         if (body) {
           var obj = JSON.parse(body);
-          resolve(obj)
+          resolve([obj])
         } else {
-          resolve(body)
+          resolve([body])
         }
       }
     });
@@ -200,9 +200,9 @@ ClientBase.prototype._putHttp = function(path, body, callback, headers) {
       if (!handleHttpError(err, response, reject)) {
         if (body) {
           var obj = JSON.parse(body);
-          resolve(obj);
+          resolve([obj]);
         } else {
-          resolve(body);
+          resolve([body]);
         }
       }
     });
@@ -212,11 +212,12 @@ ClientBase.prototype._putHttp = function(path, body, callback, headers) {
 
 ClientBase.prototype._deleteHttp = function(path, callback, headers) {
   var url = this.baseApiUri + this._setAccessToken(path);
+  var options = this._generateReqOptions(url, path, null, 'DELETE', headers)
   return this._createPromise(function (resolve, reject) {
-    request.del(url, this._generateReqOptions(url, path, null, 'DELETE', headers),
+    request.del(url, options,
       function onDel(err, response, body) {
         if (!handleHttpError(err, response, reject)) {
-          resolve(body);
+          resolve([body]);
         }
       });
   }, callback);
@@ -256,7 +257,7 @@ ClientBase.prototype._getAllHttp = function(opts, callback, headers) {
     }
   }
 
-  return new Promise(function (resolve, reject) {
+  return this._createPromise(function (resolve, reject) {
     self._getHttp(path, args, function onGet(err, result) {
       if (!handleError(err, result, reject)) {
         var objs = [];
@@ -269,15 +270,7 @@ ClientBase.prototype._getAllHttp = function(opts, callback, headers) {
         resolve([objs, result.pagination])
       }
     }, headers);
-  })
-    .then(function (result) {
-      if (callback) callback(null, result[0], result[1]);
-      return result;
-    })
-    .catch(function (err) {
-      if (callback) callback(err, null);
-      return err;
-    });
+  }, callback);
 };
 
 //
@@ -293,9 +286,9 @@ ClientBase.prototype._getOneHttp = function(args, callback, headers) {
       if (!handleError(err, obj, reject)) {
         if (obj.data.resource) {
           var ObjFunc = self._stringToClass(obj.data.resource);
-          resolve(new ObjFunc(self, obj.data))
+          resolve([new ObjFunc(self, obj.data)])
         } else {
-          resolve(obj)
+          resolve([obj])
         }
       }
     }, headers);
@@ -312,13 +305,13 @@ ClientBase.prototype._postOneHttp = function(opts, callback, headers) {
    var self = this;
    var body = opts.params;
    return this._createPromise(function (resolve, reject) {
-     this._postHttp(opts.colName, body, function onPost(err, obj) {
+     self._postHttp(opts.colName, body, function onPost(err, obj) {
        if (!handleError(err, obj, reject)) {
          if (obj.data.resource) {
            var ObjFunc = self._stringToClass(obj.data.resource);
-           resolve(new ObjFunc(self, obj.data));
+           resolve([new ObjFunc(self, obj.data)]);
          } else {
-           resolve(obj);
+           resolve([obj]);
          }
        }
      }, headers);
@@ -328,17 +321,5 @@ ClientBase.prototype._postOneHttp = function(opts, callback, headers) {
 ClientBase.prototype._stringToClass = function(name) {
   return MODELS[name]
 };
-
-ClientBase.prototype._createPromise = function(run, callback) {
-  return new Promise(run)
-    .then(function (obj) {
-      if (callback) callback(null, obj);
-      return [obj];
-    })
-    .catch(function (err) {
-      if (callback) callback(err, null);
-      return err;
-    });
-}
 
 module.exports = ClientBase;

--- a/lib/errorHandler.js
+++ b/lib/errorHandler.js
@@ -23,18 +23,14 @@ function _parseError(error) {
   }
 };
 
-function handleHttpError(err, response, callback) {
-
-  if (!callback) {
-    throw new Error("no callback for http error handler- check method signature");
-  }
+function handleHttpError(err, response, reject) {
 
   if (err) {
-    callback(err, null);
+    reject(err, null);
     return true;
   }
   if (!response) {
-    callback(createError('no response'), null);
+    reject(createError('no response'), null);
     return true;
   }
   if (response.statusCode !== 200 &&
@@ -49,29 +45,28 @@ function handleHttpError(err, response, callback) {
     } catch (ex) {
       error = createError(response.statusCode, response.body);
     }
-    callback(error, null);
+    reject(error, null);
     return true;
   }
   return false;
 }
 
-function handleError(err, obj, callback) {
+function handleError(err, obj, reject) {
 
-  if (!callback) {throw "no callback - check method signature";}
   if (err) {
-    callback(err, null);
+    reject(err);
     return true;
   }
   if (obj.error) {
-    callback(createError(obj.error, {name: 'APIError'}), null);
+    reject(createError(obj.error, {name: 'APIError'}));
     return true;
   }
   if (obj.errors) {
-    callback(createError(obj, {name: 'APIError'}), null);
+    reject(createError(obj, {name: 'APIError'}));
     return true;
   }
   if (obj.success !== undefined && obj.success !== true) {
-    callback(createError(obj, {name: 'APIError'}), null);
+    reject(createError(obj, {name: 'APIError'}));
     return true;
   }
   return false;

--- a/lib/model/Account.js
+++ b/lib/model/Account.js
@@ -37,25 +37,26 @@ Account.prototype = Object.create(AccountBase.prototype);
 
 Account.prototype.delete = function(callback) {
   var path = "accounts/" + this.id;
-  this.client._deleteHttp(path, callback);
+  return this.client._deleteHttp(path, callback);
 };
 
 Account.prototype.setPrimary = function(callback) {
   var path = "accounts/" + this.id + "/primary";
-  this.client._postHttp(path, null, callback);
+  return this.client._postHttp(path, null, callback);
 };
 
 Account.prototype.update = function(args, callback) {
   var self = this;
   var path = "accounts/" + this.id;
-  this.client._putHttp(path, args, function myPut(err, result) {
-    if (err) {
-      callback(err, null);
-      return;
-    }
-    var account = new Account(self.client, result.data);
-    callback(null, account);
-  });
+
+  return this._createPromise(function (resolve, reject) {
+    self.client._putHttp(path, args, function onPut(err, result) {
+      if (!handleError(err, result, reject)) {
+        var account = new Account(self.client, result.data);
+        resolve([account]);
+      }
+    });
+  }, callback);
 };
 
 //```
@@ -68,7 +69,7 @@ Account.prototype.getAddresses = function(args, callback) {
     'ObjFunc'  : Address,
   };
 
-  this._getAll(_.assign(args || {}, opts), callback)
+  return this._getAll(_.assign(args || {}, opts), callback)
 };
 
 Account.prototype.getAddress = function(addressId, callback) {
@@ -77,7 +78,7 @@ Account.prototype.getAddress = function(addressId, callback) {
     'ObjFunc'  : Address,
     'id'       : addressId
   };
-  this._getOne(opts, callback)
+  return this._getOne(opts, callback)
 };
 
 // ```
@@ -92,7 +93,7 @@ Account.prototype.createAddress = function(args, callback) {
     'ObjFunc'  : Address,
     'params'   : args
   };
-  this._postOne(opts, callback)
+  return this._postOne(opts, callback)
 };
 
 Account.prototype.getTransactions = function(args, callback) {
@@ -102,7 +103,7 @@ Account.prototype.getTransactions = function(args, callback) {
     'ObjFunc'  : Transaction,
   };
 
-  this._getAll(_.assign(args || {}, opts), callback)
+  return this._getAll(_.assign(args || {}, opts), callback)
 };
 
 Account.prototype.getTransaction = function(transaction_id, callback) {
@@ -113,7 +114,7 @@ Account.prototype.getTransaction = function(transaction_id, callback) {
     'id'      : transaction_id
   };
 
-  this._getOne(opts, callback);
+  return this._getOne(opts, callback);
 };
 
 //```
@@ -126,7 +127,7 @@ Account.prototype.getTransaction = function(transaction_id, callback) {
 
 Account.prototype.transferMoney = function(args, callback) {
   args.type = 'transfer';
-  this._initTxn(args, callback);
+  return this._initTxn(args, callback);
 };
 
 //```
@@ -144,7 +145,7 @@ Account.prototype.sendMoney = function(args, callback, twoFactorAuth) {
   var tfa = twoFactorAuth ? {'CB-2FA-Token': twoFactorAuth} : null;
   args.type = 'send';
 
-  this._initTxn(args, callback, tfa);
+  return this._initTxn(args, callback, tfa);
 };
 
 //```
@@ -156,7 +157,7 @@ Account.prototype.sendMoney = function(args, callback, twoFactorAuth) {
 // };
 Account.prototype.requestMoney = function(args, callback) {
   args.type = 'request';
-  this._initTxn(args, callback);
+  return this._initTxn(args, callback);
 };
 
 // Buys
@@ -167,7 +168,7 @@ Account.prototype.getBuys = function(args, callback) {
     'ObjFunc'  : Buy,
   };
 
-  this._getAll(_.assign(args || {}, opts), callback)
+  return this._getAll(_.assign(args || {}, opts), callback)
 };
 
 Account.prototype.getBuy = function(buy_id, callback) {
@@ -178,7 +179,7 @@ Account.prototype.getBuy = function(buy_id, callback) {
     'id'       : buy_id
   };
 
-  this._getOne(opts, callback);
+  return this._getOne(opts, callback);
 };
 
 
@@ -200,7 +201,7 @@ Account.prototype.buy = function(args, callback) {
     'params'   : args
   };
 
-  this._postOne(opts, callback)
+  return this._postOne(opts, callback)
 };
 
 // Sells
@@ -211,7 +212,7 @@ Account.prototype.getSells = function(args, callback) {
     'ObjFunc'  : Sell,
   };
 
-  this._getAll(_.assign(args || {}, opts), callback)
+  return this._getAll(_.assign(args || {}, opts), callback)
 };
 
 Account.prototype.getSell = function(sell_id, callback) {
@@ -222,7 +223,7 @@ Account.prototype.getSell = function(sell_id, callback) {
     'id'       : sell_id
   };
 
-  this._getOne(opts, callback);
+  return this._getOne(opts, callback);
 };
 
 
@@ -244,7 +245,7 @@ Account.prototype.sell = function(args, callback) {
     'params'   : args
   };
 
-  this._postOne(opts, callback)
+  return this._postOne(opts, callback)
 };
 
 // Deposits
@@ -255,7 +256,7 @@ Account.prototype.getDeposits = function(args, callback) {
     'ObjFunc'  : Deposit,
   };
 
-  this._getAll(_.assign(args || {}, opts), callback)
+  return this._getAll(_.assign(args || {}, opts), callback)
 };
 
 Account.prototype.getDeposit = function(deposit_id, callback) {
@@ -266,7 +267,7 @@ Account.prototype.getDeposit = function(deposit_id, callback) {
     'id'       : deposit_id
   };
 
-  this._getOne(opts, callback);
+  return this._getOne(opts, callback);
 };
 
 
@@ -285,7 +286,7 @@ Account.prototype.deposit = function(args, callback) {
     'params'   : args
   };
 
-  this._postOne(opts, callback)
+  return this._postOne(opts, callback)
 };
 
 // Withdrawals
@@ -296,7 +297,7 @@ Account.prototype.getWithdrawals = function(args, callback) {
     'ObjFunc'  : Withdrawal,
   };
 
-  this._getAll(_.assign(args || {}, opts), callback)
+  return this._getAll(_.assign(args || {}, opts), callback)
 };
 
 Account.prototype.getWithdrawal = function(withdrawal_id, callback) {
@@ -307,7 +308,7 @@ Account.prototype.getWithdrawal = function(withdrawal_id, callback) {
     'id'       : withdrawal_id
   };
 
-  this._getOne(opts, callback);
+  return this._getOne(opts, callback);
 };
 
 
@@ -326,7 +327,7 @@ Account.prototype.withdraw = function(args, callback) {
     'params'   : args
   };
 
-  this._postOne(opts, callback)
+  return this._postOne(opts, callback)
 };
 
 module.exports = Account;

--- a/lib/model/AccountBase.js
+++ b/lib/model/AccountBase.js
@@ -56,17 +56,19 @@ AccountBase.prototype._getAll = function(opts, callback, headers) {
     }
   }
 
-  this.client._getHttp(path, args, function onGet(err, result) {
-    if (!handleError(err, result, callback)) {
-      if (result.data.length > 0) {
-        var ObjFunc = self.client._stringToClass(result.data[0].resource);
+  return this._createPromise(function (resolve, reject) {
+    self.client._getHttp(path, args, function onGet(err, result) {
+      if (!handleError(err, result, reject)) {
+        if (result.data.length > 0) {
+          var ObjFunc = self.client._stringToClass(result.data[0].resource);
+        }
+        var objs = _.map(result.data, function onMap(obj) {
+          return new ObjFunc(self.client, obj, self);
+        });
+        resolve([objs, result.pagination])
       }
-      var objs = _.map(result.data, function onMap(obj) {
-        return new ObjFunc(self.client, obj, self);
-      });
-      callback(null, objs, result.pagination);
-    }
-  }, headers);
+    }, headers);
+  }, callback);
 };
 
 // INTERNAL API
@@ -81,12 +83,14 @@ AccountBase.prototype._getAll = function(opts, callback, headers) {
 AccountBase.prototype._getOne = function(opts, callback, headers) {
   var self = this;
   var path = 'accounts/' + this.id + '/' + opts.colName + '/' + opts.id;
-  this.client._getHttp(path, null, function onGet(err, obj) {
-    if (!handleError(err, obj, callback)) {
-      var ObjFunc = self.client._stringToClass(obj.data.resource);
-      callback(null, new ObjFunc(self.client, obj.data, self));
-    }
-  }, headers);
+  return this._createPromise(function (resolve, reject) {
+    self.client._getHttp(path, null, function onGet(err, obj) {
+      if (!handleError(err, obj, reject)) {
+        var ObjFunc = self.client._stringToClass(obj.data.resource);
+        resolve([new ObjFunc(self.client, obj.data, self)])
+      }
+    }, headers);
+  }, callback);
 };
 
 // ```
@@ -98,12 +102,15 @@ AccountBase.prototype._getOne = function(opts, callback, headers) {
 AccountBase.prototype._postOne = function(opts, callback, headers) {
   var self = this;
   var path = 'accounts/' + this.id + '/' + opts.colName;
-  this.client._postHttp(path, opts.params, function onPost(err, obj) {
-    if (!handleError(err, obj, callback)) {
-      var ObjFunc = self.client._stringToClass(obj.data.resource);
-      callback(null, new ObjFunc(self.client, obj.data, self));
-    }
-  }, headers);
+
+  return this._createPromise(function (resolve, reject) {
+    self.client._postHttp(path, opts.params, function onPost(err, obj) {
+      if (!handleError(err, obj, reject)) {
+        var ObjFunc = self.client._stringToClass(obj.data.resource);
+        resolve([new ObjFunc(self.client, obj.data, self)]);
+      }
+    }, headers);
+  }, callback);
 };
 
 // INTERNAL API
@@ -111,12 +118,14 @@ AccountBase.prototype._initTxn = function(args, callback, headers) {
   var self = this;
   var path = 'accounts/' + this.id + "/transactions";
 
-  this.client._postHttp(path, args, function onPost(err, obj) {
-      if (!handleError(err, obj, callback)) {
+  return this._createPromise(function (resolve, reject) {
+    self.client._postHttp(path, args, function onPost(err, obj) {
+      if (!handleError(err, obj, reject)) {
         var txn = new Transaction(self.client, obj.data, self);
-        callback(null, txn);
+        resolve([txn]);
       }
     }, headers);
+  }, callback);
 };
 
 module.exports = AccountBase;

--- a/lib/model/Address.js
+++ b/lib/model/Address.js
@@ -34,7 +34,7 @@ Address.prototype.getTransactions = function(args, callback) {
     'ObjFunc'  : Transaction,
   };
 
-  this.account._getAll(_.assign(args || {}, opts), callback)
+  return this.account._getAll(_.assign(args || {}, opts), callback)
 };
 
 module.exports = Address;

--- a/lib/model/Buy.js
+++ b/lib/model/Buy.js
@@ -27,7 +27,7 @@ Buy.prototype.commit = function(callback) {
     'ObjFunc' : Buy
   };
 
-  this._commit(opts, callback);
+  return this._commit(opts, callback);
 };
 
 module.exports = Buy;

--- a/lib/model/Checkout.js
+++ b/lib/model/Checkout.js
@@ -28,7 +28,7 @@ Checkout.prototype.getOrders = function(args, callback) {
     'ObjFunc'  : Order
   };
 
-  this.client._getAllHttp(_.assign(args || {}, opts), callback)
+  return this.client._getAllHttp(_.assign(args || {}, opts), callback)
 };
 
 Checkout.prototype.createOrder = function(callback) {
@@ -38,7 +38,7 @@ Checkout.prototype.createOrder = function(callback) {
     'ObjFunc' : Order,
   };
 
-  this.client._postOneHttp(opts, callback);
+  return this.client._postOneHttp(opts, callback);
 };
 
 module.exports = Checkout;

--- a/lib/model/Deposit.js
+++ b/lib/model/Deposit.js
@@ -27,7 +27,7 @@ Deposit.prototype.commit = function(callback) {
     'ObjFunc' : Deposit
   };
 
-  this._commit(opts, callback);
+  return this._commit(opts, callback);
 };
 
 module.exports = Deposit;

--- a/lib/model/Order.js
+++ b/lib/model/Order.js
@@ -35,12 +35,14 @@ Order.prototype.refund = function(args, callback) {
 
   var path = 'orders/' + self.id + '/refund';
 
-  self.client._postHttp(path, args, function onPost(err, result) {
-    if (!handleError(err, result, callback)) {
-      var order = new Order(self.client, result.data);
-      callback(null, order);
-    }
-  });
+  return this._createPromise(function (resolve, reject) {
+    self.client._postHttp(path, args, function onPost(err, result) {
+      if (!handleError(err, result, reject)) {
+        var order = new Order(self.client, result.data);
+        resolve([order]);
+      }
+    });
+  }, callback)
 };
 
 module.exports = Order;

--- a/lib/model/Sell.js
+++ b/lib/model/Sell.js
@@ -27,7 +27,7 @@ Sell.prototype.commit = function(callback) {
     'ObjFunc' : Sell
   };
 
-  this._commit(opts, callback);
+  return this._commit(opts, callback);
 };
 
 module.exports = Sell;

--- a/lib/model/Transaction.js
+++ b/lib/model/Transaction.js
@@ -33,11 +33,13 @@ Transaction.prototype.resend = function(callback) {
 
   var path = 'accounts/' + self.account.id +  '/transactions/' + self.id + '/resend';
 
-  self.client._postHttp(path, null, function onPut(err, result) {
-    if (!handleError(err, result, callback)) {
-      callback(null, result);
-    }
-  });
+  return this._createPromise(function (resolve, reject) {
+    self.client._postHttp(path, null, function onPut(err, result) {
+      if (!handleError(err, result, reject)) {
+        resolve([result]);
+      }
+    });
+  }, callback);
 };
 
 Transaction.prototype.complete = function(callback) {
@@ -48,11 +50,13 @@ Transaction.prototype.complete = function(callback) {
 
   var path = 'accounts/' + self.account.id +  '/transactions/' + self.id + '/complete';
 
-  self.client._postHttp(path, null, function onPut(err, result) {
-    if (!handleError(err, result, callback)) {
-      callback(null, new Transaction(self.client, result.data, self.account));
-    }
-  });
+  return this._createPromise(function (resolve, reject) {
+    self.client._postHttp(path, null, function onPut(err, result) {
+      if (!handleError(err, result, reject)) {
+        resolve([new Transaction(self.client, result.data, self.account)]);
+      }
+    });
+  }, callback);
 };
 
 Transaction.prototype.cancel = function(callback) {
@@ -63,11 +67,13 @@ Transaction.prototype.cancel = function(callback) {
 
   var path = 'accounts/' + self.account.id +  '/transactions/' + self.id;
 
-  self.client._deleteHttp(path, function onDel(err, result) {
-    if (!handleError(err, result, callback)) {
-      callback(null, result);
-    }
-  });
+  return this._createPromise(function (resolve, reject) {
+    self.client._deleteHttp(path, function onDel(err, result) {
+      if (!handleError(err, result, reject)) {
+        resolve([result]);
+      }
+    });
+  }, callback);
 };
 
 module.exports = Transaction;

--- a/lib/model/Transfer.js
+++ b/lib/model/Transfer.js
@@ -19,11 +19,13 @@ Transfer.prototype._commit = function(opts, callback) {
 
   var path = 'accounts/' + self.account.id + '/' + opts.colName + '/' + self.id + '/commit';
 
-  self.client._postHttp(path, null, function onPut(err, result) {
-    if (!handleError(err, result, callback)) {
-      callback(null, new opts.ObjFunc(self.client, result.data, self.account));
-    }
-  });
+  return this._createPromise(function(resolve, reject) {
+    self.client._postHttp(path, null, function onPut(err, result) {
+      if (!handleError(err, result, reject)) {
+        resolve([new opts.ObjFunc(self.client, result.data, self.account)])
+      }
+    });
+  }, callback);
 };
 
 module.exports = Transfer;

--- a/lib/model/User.js
+++ b/lib/model/User.js
@@ -21,28 +21,33 @@ User.prototype.update = function(args, callback) {
 
   var path = 'user';
 
-  self.client._putHttp(path, args, function onPut(err, result) {
-    if (!handleError(err, result, callback)) {
-      callback(null, new User(self.client, result.data));
-    }
-  });
+  return this._createPromise(function (resolve, reject) {
+    self.client._putHttp(path, args, function onPut(err, result) {
+      if (!handleError(err, result, reject)) {
+        resolve([new User(self.client, result.data)]);
+      }
+    });
+  }, callback)
 };
 
 User.prototype.showAuth = function(callback) {
   var self = this;
   if (!self.client) {throw "no client";}
-  if (!self.id) {
-    callback(new Error("no user id"), null);
-    return;
-  }
 
   var path = 'user/auth';
 
-  self.client._getHttp(path, null, function onGet(err, result) {
-    if (!handleError(err, result, callback)) {
-      callback(null, result.data);
+  return this._createPromise(function (resolve, reject) {
+    if (!self.id) {
+      reject(new Error("no user id"));
+      return;
     }
-  });
+
+    self.client._getHttp(path, null, function onGet(err, result) {
+      if (!handleError(err, result, reject)) {
+        resolve([result.data]);
+      }
+    });
+  }, callback)
 };
 
 module.exports = User;

--- a/lib/model/Withdrawal.js
+++ b/lib/model/Withdrawal.js
@@ -27,7 +27,7 @@ Withdrawal.prototype.commit = function(callback) {
     'ObjFunc' : Withdrawal
   };
 
-  this._commit(opts, callback);
+  return this._commit(opts, callback);
 };
 
 module.exports = Withdrawal;

--- a/test/nockAccount.js
+++ b/test/nockAccount.js
@@ -37,11 +37,13 @@ var PRIMARY_RESPONSE = {
 nock(TEST_BASE_URI)
   .filteringPath(EXPIRE_REGEX, '')
   .post('/accounts/' + ACCOUNT_1.id + '/primary')
+  .twice()
   .reply(200, PRIMARY_RESPONSE);
 
 nock(TEST_BASE_URI)
   .filteringPath(EXPIRE_REGEX, '')
   .delete('/accounts/' + ACCOUNT_3.id)
+  .twice()
   .reply(204, null);
 
 var MODIFY_ACCOUNT_RESP = {
@@ -65,6 +67,7 @@ var MODIFY_ACCOUNT_RESP = {
 nock(TEST_BASE_URI)
   .filteringPath(EXPIRE_REGEX, '')
   .put('/accounts/' + ACCOUNT_1.id)
+  .twice()
   .reply(200, function(uri, body) {
     return MODIFY_ACCOUNT_RESP;
   });
@@ -104,6 +107,7 @@ var GET_ADDRESSES_RESP =
 nock(TEST_BASE_URI)
   .filteringPath(/expire=[0-9]+/g)
   .get('/accounts/' + ACCOUNT_1.id + '/addresses')
+  .twice()
   .reply(200, function(uri, requestBody) {
     return GET_ADDRESSES_RESP;
   });
@@ -122,6 +126,7 @@ var GET_ADDRESS_RESP = {
 nock(TEST_BASE_URI)
   .filteringPath(EXPIRE_REGEX, '')
   .get('/accounts/' + ACCOUNT_1.id + '/addresses/moLxGrqWNcnGq4A8Caq8EGP4n9GUGWanj4')
+  .twice()
   .reply(200, GET_ADDRESS_RESP);
 
 var CREATE_ADDRESS_RESP = {
@@ -139,6 +144,7 @@ nock(TEST_BASE_URI)
   .post('/accounts/' + ACCOUNT_1.id + '/addresses',
         {callback_url: 'http://www.example.com/callback',
          label: 'Dalmation donations'})
+  .twice()
   .reply(201, function(uri, body) {
     return CREATE_ADDRESS_RESP;
   });
@@ -191,6 +197,7 @@ var GET_TRANSACTIONS_RESP ={
 nock(TEST_BASE_URI)
   .filteringPath(/expire=[0-9]+/g, 'expire=XXX')
   .get('/accounts/' + ACCOUNT_1.id + '/transactions')
+  .twice()
   .reply(200, function(uri, requestBody) {
     return GET_TRANSACTIONS_RESP;
   });
@@ -222,6 +229,7 @@ var GET_TRANSACTION_RESP = {
 nock(TEST_BASE_URI)
   .filteringPath(/expire=[0-9]+/g, 'expire=XXX')
   .get('/accounts/' + ACCOUNT_1.id + '/transactions/1234')
+  .twice()
   .reply(200, function(uri, requestBody) {
     return GET_TRANSACTION_RESP;
   });
@@ -262,6 +270,7 @@ nock(TEST_BASE_URI)
          "amount": "1.234",
          "notes": "Sample transaction for you",
          "type": "transfer"})
+  .twice()
   .reply(201, function(uri, body) {
     return TRANSFER_MONEY_RESP;
   });
@@ -301,6 +310,7 @@ nock(TEST_BASE_URI)
          "amount": "1.234",
          "notes": "Sample transaction for you",
          "type": "send"})
+  .twice()
   .reply(201, function(uri, body) {
     return SEND_MONEY_RESP;
   });
@@ -337,6 +347,7 @@ nock(TEST_BASE_URI)
          "amount": "1.234",
          "notes": "Sample transaction for you",
          "type": "request"})
+  .twice()
   .reply(201, function(uri, body) {
     return REQUEST_MONEY_RESP;
   });
@@ -382,6 +393,7 @@ var GET_BUYS_RESP = {
 nock(TEST_BASE_URI)
   .filteringPath(/expire=[0-9]+/g, 'expire=XXX')
   .get('/accounts/' + ACCOUNT_1.id + '/buys')
+  .twice()
   .reply(200, function(uri, requestBody) {
     return GET_BUYS_RESP;
   });
@@ -422,6 +434,7 @@ var BUY_RESP = {
 nock(TEST_BASE_URI)
   .filteringPath(EXPIRE_REGEX, '')
   .post('/accounts/' + ACCOUNT_1.id + '/buys')
+  .twice()
   .reply(201, function(uri, body) {
     return BUY_RESP;
   });

--- a/test/nockCheckout.js
+++ b/test/nockCheckout.js
@@ -36,6 +36,7 @@ var GET_CHECKOUT_RESP = {
 nock(TEST_BASE_URI)
   .filteringPath(EXPIRE_REGEX, '')
   .get('/checkouts/' + GET_CHECKOUT_RESP.data.code)
+  .twice()
   .reply(200, function(uri, requestBody) {
     return GET_CHECKOUT_RESP;
   });
@@ -72,6 +73,7 @@ var buttonOrdersPath = '/checkouts/' + GET_CHECKOUT_RESP.data.id + '/orders';
 nock(TEST_BASE_URI)
   .filteringPath(/expire=[0-9]+/g, 'expire=XXX')
   .get(buttonOrdersPath)
+  .twice()
   .reply(200, function(uri, body) {
     return GET_ORDERS_RESP;
   });
@@ -80,6 +82,7 @@ nock(TEST_BASE_URI)
 nock(TEST_BASE_URI)
   .filteringPath(EXPIRE_REGEX, '')
   .get('/checkouts/' + GET_CHECKOUT_RESP.data.id)
+  .twice()
   .reply(200, function(uri, requestBody) {
     return GET_CHECKOUT_RESP;
   });
@@ -114,6 +117,7 @@ var buttonCreatePath = '/checkouts/' + GET_CHECKOUT_RESP.data.id + '/orders';
 nock(TEST_BASE_URI)
   .filteringPath(EXPIRE_REGEX, '')
   .post(buttonCreatePath)
+  .twice()
   .reply(200, function(uri, body) {
     return CREATE_ORDER_RESP;
   });

--- a/test/nockClient.js
+++ b/test/nockClient.js
@@ -17,6 +17,7 @@ var GET_ACCOUNTS_RESP = {
 var scope1 = nock(TEST_BASE_URI)
                 .filteringPath(EXPIRE_REGEX, '')
                 .get('/accounts')
+                .twice()
                 .reply(200, GET_ACCOUNTS_RESP);
 
 var GET_ACCOUNT_RESP = {
@@ -41,6 +42,7 @@ var GET_ACCOUNT_RESP = {
 nock(TEST_BASE_URI)
   .filteringPath(EXPIRE_REGEX, '')
   .get('/accounts/' + ACCOUNTS_ID_1)
+  .twice()
   .reply(200, function(uri, body) {
     return GET_ACCOUNT_RESP;
   });
@@ -68,6 +70,7 @@ var CREATE_ACCOUNT_RESP = {
 nock(TEST_BASE_URI)
   .filteringPath(EXPIRE_REGEX, '')
   .post('/accounts')
+  .twice()
   .reply(201, function(uri, body) {
     return CREATE_ACCOUNT_RESP;
   });
@@ -107,6 +110,7 @@ var GET_CURRENT_USER_RESP = {
 nock(TEST_BASE_URI)
   .filteringPath(EXPIRE_REGEX, '')
   .get('/user')
+  .twice()
   .reply(200, function(uri, body) {
     return GET_CURRENT_USER_RESP;
   });
@@ -120,7 +124,7 @@ var GET_BUY_PRICE_RESP = {
 nock(TEST_BASE_URI)
   .filteringPath(/expire=[0-9]+/g, 'expire=XXX')
   .get('/prices/BTC-USD/buy')
-  .thrice()
+  .times(6)
   .reply(200, function(uri, body) {
     return GET_BUY_PRICE_RESP;
   });
@@ -134,7 +138,7 @@ var GET_SELL_PRICE_RESP = {
 nock(TEST_BASE_URI)
   .filteringPath(/expire=[0-9]+/g, 'expire=XXX')
   .get('/prices/BTC-USD/sell')
-  .thrice()
+  .times(6)
   .reply(200, function(uri, body) {
     return GET_SELL_PRICE_RESP;
   });
@@ -147,11 +151,11 @@ var GET_SPOT_RESP = {
 };
 nock(TEST_BASE_URI)
   .filteringPath(EXPIRE_REGEX, '')
- .get('/prices/BTC-USD/spot')
- .thrice()
- .reply(200, function(uri, body) {
-   return GET_SPOT_RESP;
- });
+  .get('/prices/BTC-USD/spot')
+  .times(6)
+  .reply(200, function(uri, body) {
+    return GET_SPOT_RESP;
+  });
 
 var GET_CURRENCIES_RESP = {
   "data": [
@@ -179,10 +183,11 @@ var GET_CURRENCIES_RESP = {
 };
 nock(TEST_BASE_URI)
   .filteringPath(EXPIRE_REGEX, '')
- .get('/currencies')
- .reply(200, function(uri, body) {
-   return GET_CURRENCIES_RESP;
- });
+  .get('/currencies')
+  .twice()
+  .reply(200, function(uri, body) {
+    return GET_CURRENCIES_RESP;
+  });
 
 var GET_EX_RATES_RESP = {
   "data": {
@@ -205,10 +210,11 @@ var GET_EX_RATES_RESP = {
 
 nock(TEST_BASE_URI)
   .filteringPath(EXPIRE_REGEX, '')
- .get('/exchange-rates')
- .reply(200, function(uri, body) {
-   return GET_EX_RATES_RESP;
- });
+  .get('/exchange-rates')
+  .twice()
+  .reply(200, function(uri, body) {
+    return GET_EX_RATES_RESP;
+  });
 
 var GET_PAYMENT_METHODS_RESP = {
   "data": [
@@ -230,10 +236,11 @@ var GET_PAYMENT_METHODS_RESP = {
 };
 nock(TEST_BASE_URI)
  .filteringPath(EXPIRE_REGEX, '')
- .get('/payment-methods')
- .reply(200, function(uri, body) {
-   return GET_PAYMENT_METHODS_RESP;
- });
+  .get('/payment-methods')
+  .twice()
+  .reply(200, function(uri, body) {
+    return GET_PAYMENT_METHODS_RESP;
+  });
 
 var GET_PAYMENT_METHOD_RESP = {
   "data": {
@@ -247,6 +254,7 @@ var GET_PAYMENT_METHOD_RESP = {
 nock(TEST_BASE_URI)
   .filteringPath(EXPIRE_REGEX, '')
   .get('/payment-methods/' + GET_PAYMENT_METHOD_RESP.data.id)
+  .twice()
   .reply(200, function(uri, body) {
     return GET_PAYMENT_METHOD_RESP;
   });

--- a/test/nockOrder.js
+++ b/test/nockOrder.js
@@ -51,6 +51,7 @@ var refund_uri = '/orders/' + REFUND_RESP.data.id + '/refund';
 nock(TEST_BASE_URI)
   .filteringPath(EXPIRE_REGEX, '')
   .post(refund_uri)
+  .twice()
   .reply(200, function(uri, requestBody) {
     return REFUND_RESP;
   });

--- a/test/nockTransaction.js
+++ b/test/nockTransaction.js
@@ -38,6 +38,7 @@ var TXN_1 = {
 nock(TEST_BASE_URI)
   .filteringPath(EXPIRE_REGEX, '')
   .post('/accounts/' + ACCOUNT_1.id + '/transactions/' + TXN_1.id + '/resend')
+  .twice()
   .reply(200, function(uri, requestBody) {
     return null;
   });
@@ -68,6 +69,7 @@ var COMPLETE_RESP = {
 nock(TEST_BASE_URI)
   .filteringPath(EXPIRE_REGEX, '')
   .post('/accounts/' + ACCOUNT_1.id + '/transactions/' + TXN_1.id + '/complete')
+  .twice()
   .reply(200, function(uri, requestBody) {
     return COMPLETE_RESP;
   });
@@ -75,6 +77,7 @@ nock(TEST_BASE_URI)
 nock(TEST_BASE_URI)
   .filteringPath(EXPIRE_REGEX, '')
   .delete('/accounts/' + ACCOUNT_1.id + '/transactions/' + TXN_1.id)
+  .twice()
   .reply(200, function(uri, requestBody) {
     return null;
   });

--- a/test/nockTransfer.js
+++ b/test/nockTransfer.js
@@ -93,6 +93,7 @@ var COMMIT_RESP = {
 nock(TEST_BASE_URI)
   .filteringPath(EXPIRE_REGEX, '')
   .post('/accounts/544955d2629122efb000000f/buys/' + XFER_1.id + '/commit')
+  .twice()
   .reply(200, function(uri, requestBody) {
     return COMMIT_RESP;
   });

--- a/test/nockUser.js
+++ b/test/nockUser.js
@@ -64,6 +64,7 @@ var MODIFY_RESP = {
 nock(TEST_BASE_URI)
   .filteringPath(EXPIRE_REGEX, '')
   .put('/user', {'native_currency': 'CAD'})
+  .twice()
   .reply(200, function(uri, requestBody) {
     var args = JSON.parse(requestBody);
     return MODIFY_RESP;

--- a/test/testAccount.js
+++ b/test/testAccount.js
@@ -56,12 +56,17 @@ describe('model.Account', function(){
         assert.equal(err, null, err);
         assert(result);
       });
+      return btcAccount.setPrimary()
+        .then(function (result) {
+          assert(result[0]);
+        })
     });
 
     it('should delete account', function() {
       usdAccount1.delete(function(err, result) {
         assert.equal(err, null, err);
       });
+      return usdAccount1.delete();
     });
 
     it('should modify account', function() {
@@ -71,6 +76,14 @@ describe('model.Account', function(){
         assert(account);
         assert.equal(account.name, na.MODIFY_ACCOUNT_RESP.data.name, "can not modify account");
       });
+      return btcAccount.update(args)
+        .then(function (result) {
+          assert(result);
+          assert.equal(result.length, 1)
+          var account = result[0]
+          assert(account);
+          assert.equal(account.name, na.MODIFY_ACCOUNT_RESP.data.name, "can not modify account");
+        });
     });
 
     it('should get addresses', function() {
@@ -80,6 +93,12 @@ describe('model.Account', function(){
         assert.equal(result.length, na.GET_ADDRESSES_RESP.data.length,
           "can not get addresses: " + JSON.stringify(result));
       });
+      return btcAccount.getAddresses(null)
+        .then(function (result) {
+          assert(result[0]);
+          assert.equal(result[0].length, na.GET_ADDRESSES_RESP.data.length,
+            "can not get addresses: " + JSON.stringify(result[0]));
+        });
     });
 
     it('should get address', function() {
@@ -91,6 +110,14 @@ describe('model.Account', function(){
         assert.equal(result.label, na.GET_ADDRESS_RESP.data.label,
           "can not get address: " + JSON.stringify(result));
       });
+      return btcAccount.getAddress(na.GET_ADDRESS_RESP.data.address)
+        .then(function (result) {
+          assert(result[0]);
+          assert.equal(result[0].id, na.GET_ADDRESS_RESP.data.id,
+            "can not get address: " + JSON.stringify(result[0]));
+          assert.equal(result[0].label, na.GET_ADDRESS_RESP.data.label,
+            "can not get address: " + JSON.stringify(result[0]));
+        });
     });
 
     it('should create address', function() {
@@ -104,6 +131,12 @@ describe('model.Account', function(){
         assert.equal(result.label, na.CREATE_ADDRESS_RESP.data.label,
           "can not create address: " + JSON.stringify(result));
       });
+      return btcAccount.createAddress(args)
+        .then(function (result) {
+          assert(result[0]);
+          assert.equal(result[0].label, na.CREATE_ADDRESS_RESP.data.label,
+            "can not create address: " + JSON.stringify(result[0]));
+        });
     });
 
     it('should get transactions', function() {
@@ -114,6 +147,13 @@ describe('model.Account', function(){
           na.GET_TRANSACTIONS_RESP.data.length,
           "can not get transactions: " + JSON.stringify(result));
       });
+      return btcAccount.getTransactions(null)
+        .then(function (result) {
+          assert(result[0]);
+          assert.equal(result[0].length,
+            na.GET_TRANSACTIONS_RESP.data.length,
+            "can not get transactions: " + JSON.stringify(result[0]));
+        });
     });
 
     it('should get transaction', function() {
@@ -123,6 +163,12 @@ describe('model.Account', function(){
         assert.equal(txn.id, na.GET_TRANSACTION_RESP.data.id,
           "can not get txn: " + JSON.stringify(txn));
       });
+      return btcAccount.getTransaction('1234')
+        .then(function (result) {
+          assert(result[0]);
+          assert.equal(result[0].id, na.GET_TRANSACTION_RESP.data.id,
+            "can not get txn: " + JSON.stringify(result[0]));
+        });
     });
 
     it('should transfer money', function() {
@@ -137,6 +183,12 @@ describe('model.Account', function(){
         assert.equal(txn.id, na.TRANSFER_MONEY_RESP.data.id,
           "can not transfer money: " + JSON.stringify(txn));
       });
+      return btcAccount.transferMoney(args)
+        .then(function (result) {
+          assert(result[0]);
+          assert.equal(result[0].id, na.TRANSFER_MONEY_RESP.data.id,
+            "can not transfer money: " + JSON.stringify(result[0]));
+        });
     });
 
     it('should send money', function() {
@@ -151,6 +203,12 @@ describe('model.Account', function(){
         assert.equal(txn.id, na.SEND_MONEY_RESP.data.id,
           "can not send money: " + JSON.stringify(txn));
       });
+      return btcAccount.sendMoney(args)
+        .then(function (result) {
+          assert(result[0]);
+          assert.equal(result[0].id, na.SEND_MONEY_RESP.data.id,
+            "can not send money: " + JSON.stringify(result[0]));
+        });
     });
 
     it('should request money', function() {
@@ -165,6 +223,12 @@ describe('model.Account', function(){
         assert.equal(txn.id, na.REQUEST_MONEY_RESP.data.id,
           "can not request money: " + JSON.stringify(txn));
       });
+      return btcAccount.requestMoney(args)
+        .then(function (result) {
+          assert(result[0]);
+          assert.equal(result[0].id, na.REQUEST_MONEY_RESP.data.id,
+            "can not request money: " + JSON.stringify(result[0]));
+        });
     });
 
     it('should get transfers', function() {
@@ -175,6 +239,13 @@ describe('model.Account', function(){
           na.GET_BUYS_RESP.data.length,
           "can not get transfers: " + JSON.stringify(result));
       });
+      return btcAccount.getBuys(null)
+        .then(function (result) {
+          assert(result[0]);
+          assert.equal(result[0].length,
+            na.GET_BUYS_RESP.data.length,
+            "can not get transfers: " + JSON.stringify(result[0]));
+        });
     });
 
     it('should buy', function() {
@@ -187,6 +258,12 @@ describe('model.Account', function(){
         assert.equal(transfer.id, na.BUY_RESP.data.id,
           "can not buy: " + JSON.stringify(transfer));
       });
+      return btcAccount.buy(args)
+        .then(function (result) {
+          assert(result[0]);
+          assert.equal(result[0].id, na.BUY_RESP.data.id,
+            "can not buy: " + JSON.stringify(result[0]));
+        });
     });
   });
 });

--- a/test/testCheckout.js
+++ b/test/testCheckout.js
@@ -60,6 +60,18 @@ describe('model.Checkout', function(){
           assert.equal(order[0].id, na.GET_ORDERS_RESP.data[0].id);
         });
       });
+
+      return client.getCheckout(na.GET_CHECKOUT_RESP.data.code)
+        .then(function (result) {
+          assert(result[0]);
+
+          return result[0].getOrders(null);
+        })
+        .then(function (result) {
+          assert(result[0]);
+          var order = result[0];
+          assert.equal(order[0].id, na.GET_ORDERS_RESP.data[0].id);
+        });
     });
 
     it('should create order', function() {
@@ -72,7 +84,15 @@ describe('model.Checkout', function(){
           assert.equal(order.id, na.CREATE_ORDER_RESP.data.id);
         });
       });
-
+      return client.getCheckout(na.GET_CHECKOUT_RESP.data.id)
+        .then(function (result) {
+          assert(result[0]);
+          return result[0].createOrder();
+        })
+        .then(function (result) {
+          assert(result[0]);
+          assert.equal(result[0].id, na.CREATE_ORDER_RESP.data.id);
+        });
     });
   });
 });

--- a/test/testClient.js
+++ b/test/testClient.js
@@ -78,6 +78,17 @@ describe('Client', function() {
         assert.equal(accounts[1].id, na.ACCOUNTS_ID_2,
           "wrong account id: " + accounts[1].id);
       });
+      return client.getAccounts({})
+        .then(function (result) {
+          assert(result[0]);
+          var accounts = result[0];
+          assert(accounts, "no accounts");
+          assert.equal(accounts.length, 2, "wrong number of accounts");
+          assert.equal(accounts[0].id, na.ACCOUNTS_ID_1,
+            "wrong account id: " + accounts[0].id);
+          assert.equal(accounts[1].id, na.ACCOUNTS_ID_2,
+            "wrong account id: " + accounts[1].id);
+        });
     });
 
     it('should get account', function() {
@@ -86,6 +97,11 @@ describe('Client', function() {
         assert(account, 'no account');
         assert.equal(account.id, na.ACCOUNTS_ID_1, 'wrong account');
       });
+      return client.getAccount(na.ACCOUNTS_ID_1)
+        .then(function (result) {
+          assert(result[0], 'no account');
+          assert.equal(result[0].id, na.ACCOUNTS_ID_1, 'wrong account');
+        });
     });
 
     it('should create account', function() {
@@ -98,6 +114,12 @@ describe('Client', function() {
         assert(account.name, 'no name');
         assert.equal(account.name, na.NEW_ACCOUNT_NAME_1, 'wrong account name');
       });
+      return client.createAccount(args)
+        .then(function (result) {
+          assert(result[0], 'no account]');
+          assert(result[0].name, 'no name');
+          assert.equal(result[0].name, na.NEW_ACCOUNT_NAME_1, 'wrong account name');
+        });
     });
 
     it('should get current user', function() {
@@ -110,6 +132,14 @@ describe('Client', function() {
           'wrong user: ' + user.name);
 
       });
+      return client.getCurrentUser()
+        .then(function (result) {
+          assert(result[0], 'no user');
+          assert(result[0].name, "no email");
+          assert.equal(result[0].name,
+            na.GET_CURRENT_USER_RESP.data.name,
+            'wrong user: ' + result[0].name);
+        });
     });
 
     it('should get buy price (undefined)', function() {
@@ -121,6 +151,14 @@ describe('Client', function() {
           na.GET_BUY_PRICE_RESP.data.amount,
           'wrong amount: ' + obj.data.amount);
       });
+      return client.getBuyPrice({})
+        .then(function (result) {
+          assert(result[0], 'no price');
+          assert(result[0].data.amount, 'no amount');
+          assert.equal(result[0].data.amount,
+            na.GET_BUY_PRICE_RESP.data.amount,
+            'wrong amount: ' + result[0].data.amount);
+        });
     });
 
     it('should get buy price (USD)', function() {
@@ -132,6 +170,14 @@ describe('Client', function() {
           na.GET_BUY_PRICE_RESP.data.amount,
           'wrong amount: ' + obj.data.amount);
       });
+      return client.getBuyPrice({currency: 'USD'})
+        .then(function (result) {
+          assert(result[0], 'no price');
+          assert(result[0].data.amount, 'no amount');
+          assert.equal(result[0].data.amount,
+            na.GET_BUY_PRICE_RESP.data.amount,
+            'wrong amount: ' + result[0].data.amount);
+        });
     });
 
     it('should get buy price (BTC-USD)', function() {
@@ -143,6 +189,14 @@ describe('Client', function() {
           na.GET_BUY_PRICE_RESP.data.amount,
           'wrong amount: ' + obj.data.amount);
       });
+      return client.getBuyPrice({currencyPair: 'BTC-USD'})
+        .then(function (result) {
+          assert(result[0], 'no price');
+          assert(result[0].data.amount, 'no amount');
+          assert.equal(result[0].data.amount,
+            na.GET_BUY_PRICE_RESP.data.amount,
+            'wrong amount: ' + result[0].data.amount);
+        });
     });
 
     it('should get sell price (undefined)', function() {
@@ -154,6 +208,14 @@ describe('Client', function() {
           na.GET_BUY_PRICE_RESP.data.amount,
           'wrong amount: ' + obj.data.amount);
       });
+      return client.getSellPrice({})
+        .then(function (result) {
+          assert(result[0], 'no price');
+          assert(result[0].data.amount, 'no amount');
+          assert.equal(result[0].data.amount,
+            na.GET_BUY_PRICE_RESP.data.amount,
+            'wrong amount: ' + result[0].data.amount);
+        });
     });
 
     it('should get sell price (USD)', function() {
@@ -165,6 +227,14 @@ describe('Client', function() {
           na.GET_BUY_PRICE_RESP.data.amount,
           'wrong amount: ' + obj.data.amount);
       });
+      return client.getSellPrice({currency: 'USD'})
+        .then(function (result) {
+          assert(result[0], 'no price');
+          assert(result[0].data.amount, 'no amount');
+          assert.equal(result[0].data.amount,
+            na.GET_BUY_PRICE_RESP.data.amount,
+            'wrong amount: ' + result[0].data.amount);
+        });
     });
 
     it('should get sell price (BTC-USD)', function() {
@@ -176,6 +246,14 @@ describe('Client', function() {
           na.GET_BUY_PRICE_RESP.data.amount,
           'wrong amount: ' + obj.data.amount);
       });
+      return client.getSellPrice({currencyPair: 'BTC-USD'})
+        .then(function (result) {
+          assert(result[0], 'no price');
+          assert(result[0].data.amount, 'no amount');
+          assert.equal(result[0].data.amount,
+            na.GET_BUY_PRICE_RESP.data.amount,
+            'wrong amount: ' + result[0].data.amount);
+        });
     });
 
     it('should get spot price (undefined)', function() {
@@ -187,6 +265,14 @@ describe('Client', function() {
           na.GET_SPOT_RESP.data.amount,
           'wrong amount: ' + obj.data.amount);
       });
+      return client.getSpotPrice({})
+        .then(function (result) {
+          assert(result[0], 'no price');
+          assert(result[0].data.amount, 'no amount');
+          assert.equal(result[0].data.amount,
+            na.GET_SPOT_RESP.data.amount,
+            'wrong amount: ' + result[0].data.amount);
+        });
     });
 
     it('should get spot price (USD)', function() {
@@ -198,6 +284,14 @@ describe('Client', function() {
           na.GET_SPOT_RESP.data.amount,
           'wrong amount: ' + obj.data.amount);
       });
+      return client.getSpotPrice({currency: 'USD'})
+        .then(function (result) {
+          assert(result[0], 'no price');
+          assert(result[0].data.amount, 'no amount');
+          assert.equal(result[0].data.amount,
+            na.GET_SPOT_RESP.data.amount,
+            'wrong amount: ' + result[0].data.amount);
+        });
     });
 
     it('should get spot price (BTC-USD)', function() {
@@ -209,6 +303,14 @@ describe('Client', function() {
           na.GET_SPOT_RESP.data.amount,
           'wrong amount: ' + obj.data.amount);
       });
+      return client.getSpotPrice({currencyPair: 'BTC-USD'})
+        .then(function (result) {
+          assert(result[0], 'no price');
+          assert(result[0].data.amount, 'no amount');
+          assert.equal(result[0].data.amount,
+            na.GET_SPOT_RESP.data.amount,
+            'wrong amount: ' + result[0].data.amount);
+        });
     });
 
     it('should get supported currencies', function() {
@@ -219,6 +321,13 @@ describe('Client', function() {
           na.GET_CURRENCIES_RESP.length,
           'wrong number of currencies: ' + obj.length);
       });
+      return client.getCurrencies()
+        .then(function (result) {
+          assert(result[0], 'no currencies');
+          assert.equal(result[0].length,
+            na.GET_CURRENCIES_RESP.length,
+            'wrong number of currencies: ' + result[0].length);
+        });
     });
 
     it('should get exchange rates', function() {
@@ -230,6 +339,14 @@ describe('Client', function() {
           na.GET_EX_RATES_RESP.data.rates.AED,
           'wrong rate: ' + obj.data.rates.AED);
       });
+      return client.getExchangeRates({})
+        .then(function (result) {
+          assert(result[0], 'no rates');
+          assert(result[0].data.rates, "no rate");
+          assert.equal(result[0].data.rates.AED,
+            na.GET_EX_RATES_RESP.data.rates.AED,
+            'wrong rate: ' + result[0].data.rates.AED);
+        });
     });
 
     it('should get payment methods', function() {
@@ -240,6 +357,13 @@ describe('Client', function() {
           na.GET_PAYMENT_METHODS_RESP.data.length,
           'wrong number of methods: ' + pms.length);
       });
+      return client.getPaymentMethods({})
+        .then(function (result) {
+          assert(result[0], 'no payment methods');
+          assert.equal(result[0].length,
+            na.GET_PAYMENT_METHODS_RESP.data.length,
+            'wrong number of methods: ' + result[0].length);
+        });
     });
 
     it('should get payment method', function() {
@@ -250,6 +374,12 @@ describe('Client', function() {
         assert.equal(pm.id, na.GET_PAYMENT_METHOD_RESP.data.id,
           'wrong payment method');
       });
+      return client.getPaymentMethod(na.GET_PAYMENT_METHOD_RESP.data.id)
+        .then(function (result) {
+          assert(result[0], 'no payment method');
+          assert.equal(result[0].id, na.GET_PAYMENT_METHOD_RESP.data.id,
+            'wrong payment method');
+        });
     });
 
     it('should verify a legitimate merchant callback', function() {

--- a/test/testOrder.js
+++ b/test/testOrder.js
@@ -51,6 +51,15 @@ describe('model.Order', function(){
         assert.equal(order.refund_transaction.id,
           na.REFUND_RESP.data.refund_transaction.id, 'no refund txn');
       });
+      return order.refund(args)
+        .then(function (result) {
+          assert(result[0], 'no refund');
+          assert(result[0].id);
+          assert.equal(result[0].id, na.REFUND_RESP.data.id, 'wrong order');
+          assert(result[0].refund_transaction.id);
+          assert.equal(result[0].refund_transaction.id,
+            na.REFUND_RESP.data.refund_transaction.id, 'no refund txn');
+        });
     });
   });
 });

--- a/test/testTransaction.js
+++ b/test/testTransaction.js
@@ -50,6 +50,7 @@ describe('model.Transaction', function(){
       txn.resend(function(err, res) {
         assert.equal(err, null, err);
       });
+      return txn.resend();
     });
 
     it('should complete transaction', function() {
@@ -61,12 +62,21 @@ describe('model.Transaction', function(){
           'wrong txn id');
         assert.equal(txn.status, 'pending', 'wrong txn status');
       });
+      return txn.complete()
+        .then(function (result) {
+          assert(result[0], 'no txn');
+          assert(result[0].id, 'no txn id');
+          assert.equal(result[0].id, na.COMPLETE_RESP.data.id,
+            'wrong txn id');
+          assert.equal(result[0].status, 'pending', 'wrong txn status');
+        });
     });
 
     it('should cancel transaction', function() {
       txn.cancel(function(err, res) {
         assert.equal(err, null, err);
       });
+      return txn.cancel();
     });
   });
 });

--- a/test/testTransfer.js
+++ b/test/testTransfer.js
@@ -53,6 +53,10 @@ describe('model.Buy', function(){
         assert.equal(err, null, err);
         assert(update, 'no updated xfer');
       });
+      return xfer.commit()
+        .then(function (result) {
+          assert(result[0], 'no updated xfer');
+        });
     });
   });
 });

--- a/test/testUser.js
+++ b/test/testUser.js
@@ -49,6 +49,11 @@ describe('model.User', function(){
         assert(update, 'no updated user');
         assert.equal(update.native_currency, 'CAD', 'not updated');
       });
+      return user.update(args)
+        .then(function (result) {
+          assert(result[0], 'no updated user');
+          assert.equal(result[0].native_currency, 'CAD', 'not updated');
+        });
     });
 
   });


### PR DESCRIPTION
Added Promise support without breaking api, except callback being mandatory.
Usage:
```javascript
client.getAccounts({})
  .then(function(result) {
    var accounts = result[0]
    console.log('then', accounts)
  })
  .catch(function (err) {
    console.log('catch', err)
  });
```
I decided to return the result as array to support pagination. One can use it quite convenient using ES6 features as below:
```javascript
client.getAccounts({})
  .then(([accounts]) => {
    console.log('then', accounts)
  })
  .catch((err) => {
    console.log('catch', err)
  })
```