### PR TITLE
added Deposit createDeposit() with unit tests and mocks

### DIFF
--- a/lib/model/Deposit.js
+++ b/lib/model/Deposit.js
@@ -20,6 +20,30 @@ function Deposit(client, data, account) {
 
 Deposit.prototype = Object.create(Transfer.prototype);
 
+/**
+ * Create a new deposit.
+ * @param {Object} opts 
+ * @param {Number} opts.amount              Deposit amount. ex 0.213    
+ * @param {String} opts.currency            Currency for the amount. ex: 'USD'
+ * @param {String} opts.paymentMethod       The ID of the payment method that should be used for the deposit. Payment methods can be listed using the client.getPaymentMethods(opts, cb) call
+ * @param {Boolean} opts.commit             If set to false, this deposit will not be immediately completed. Use the commit call to complete it. Default value: true
+ * @param {Function} callback 
+ */
+Deposit.prototype.createDeposit = function(opts, callback) {
+  const path = 'accounts/' + this.account.id + '/deposits';
+  const requestBody = {
+    amount: opts.amount.toString(),
+    currency: opts.currency,
+    'payment_method': opts.paymentMethod,
+    commit: typeof opts.commit === 'undefined' ? true : opts.commit
+  }
+  this.client._postHttp(path, requestBody, (err, result) => {
+    if (!handleError(err, result, callback)) {
+      callback(null, result.data);
+    }
+  });
+}
+
 Deposit.prototype.commit = function(callback) {
 
   var opts = {

--- a/test/nockDeposit.js
+++ b/test/nockDeposit.js
@@ -1,0 +1,56 @@
+/*jslint node: true */
+/*jslint unparam: true */
+
+var nock     = require('nock');
+
+var EXPIRE_REGEX = /\?expire=[0-9]+/g;
+
+var TEST_BASE_URI = 'http://mockapi.coinbase.com/v2/';
+
+var CREATE_DEPOSIT_RESP = {
+  "data": {
+    "id": "67e0eaec-07d7-54c4-a72c-2e92826897df",
+    "status": "created",
+    "payment_method": {
+      "id": "83562370-3e5c-51db-87da-752af5ab9559",
+      "resource": "payment_method",
+      "resource_path": "/v2/payment-methods/83562370-3e5c-51db-87da-752af5ab9559"
+    },
+    "transaction": {
+      "id": "441b9494-b3f0-5b98-b9b0-4d82c21c252a",
+      "resource": "transaction",
+      "resource_path": "/v2/accounts/2bbf394c-193b-5b2a-9155-3b4732659ede/transactions/441b9494-b3f0-5b98-b9b0-4d82c21c252a"
+    },
+    "amount": {
+      "amount": "10.00",
+      "currency": "USD"
+    },
+    "subtotal": {
+      "amount": "10.00",
+      "currency": "USD"
+    },
+    "created_at": "2015-01-31T20:49:02Z",
+    "updated_at": "2015-02-11T16:54:02-08:00",
+    "resource": "deposit",
+    "resource_path": "/v2/accounts/2bbf394c-193b-5b2a-9155-3b4732659ede/deposits/67e0eaec-07d7-54c4-a72c-2e92826897df",
+    "committed": true,
+    "fee": {
+      "amount": "0.00",
+      "currency": "USD"
+    },
+    "payout_at": "2015-02-18T16:54:00-08:00"
+  }
+}
+
+const deposit_uri = '/accounts/' + CREATE_DEPOSIT_RESP.data.id + '/deposits';
+
+nock(TEST_BASE_URI)
+  .filteringPath(EXPIRE_REGEX, '')
+  .post(deposit_uri)
+  .reply(200, function(uri, requestBody) {
+    return CREATE_DEPOSIT_RESP;
+  });
+
+module.exports.TEST_BASE_URI     = TEST_BASE_URI    ;
+module.exports.CREATE_DEPOSIT_RESP = CREATE_DEPOSIT_RESP;
+

--- a/test/testDeposit.js
+++ b/test/testDeposit.js
@@ -1,0 +1,70 @@
+/*jslint node: true */
+/*jslint unparam: true */
+/*global describe:true*/
+/*global it:true*/
+/*global xdescribe:true*/
+/*global xit:true*/
+
+var assert   = require("assert");
+var coinbase = require('..');
+var Client   = coinbase.Client;
+// var Account  = coinbase.model.Account;
+var Deposit = coinbase.model.Deposit;
+var na       = require('./nockDeposit.js');
+
+describe('model.Deposit', function(){
+
+  describe('deposit constructor', function(){
+
+    it('should return deposit', function(){
+      var deposit = new Deposit(
+        {},
+        {'id': '999'},
+        {'id': '999'}
+        );
+      assert(deposit);
+    });
+
+    it('should require constructor call', function(){
+      var deposit = Deposit(
+        {},
+        {'id': '999'},
+        {'id': '999'}
+        );
+      assert(deposit instanceof Deposit);
+    });
+    it('should require constructor args', function(){
+      try {
+        Deposit({});
+      } catch(err) {
+        assert(true);
+        return;
+      }
+      assert(false);
+    });
+
+  });
+
+  describe('deposit methods', function() {
+
+    var client = new Client({'apiKey': 'mykey', 'apiSecret': 'mysecret', 'baseApiUri': na.TEST_BASE_URI});
+
+    it('should create deposit', () => {
+      const deposit = new Deposit(client, { id: na.CREATE_DEPOSIT_RESP.data.id }, {  id: na.CREATE_DEPOSIT_RESP.data.id });
+      const amount = 0.25;
+      const currency = 'USD';
+      const paymentMethod = na.CREATE_DEPOSIT_RESP.data['payment_method'].id;
+      deposit.createDeposit({
+        amount,
+        currency,
+        paymentMethod
+      }, (err, deposit) => {
+        assert.equal(err, undefined);
+        assert.equal(deposit.id, na.CREATE_DEPOSIT_RESP.data.id);
+        assert.equal(deposit['payment_method'].id, na.CREATE_DEPOSIT_RESP.data['payment_method'].id);
+        assert.equal(deposit.resource, 'deposit');
+      });
+    });
+  });
+});
+


### PR DESCRIPTION
for #105 

Added a `Deposit.createDeposit()` method, with unit test and server mock.

Not tested against real server yet, only via using a mock matching the example response from the [API docs](https://developers.coinbase.com/api/v2?shell#deposit-funds).