### PR TITLE
Add default timeout to REST calls

### DIFF
--- a/lib/ClientBase.js
+++ b/lib/ClientBase.js
@@ -66,7 +66,8 @@ function ClientBase(opts) {
     baseApiUri: BASE_URI,
     tokenUri: TOKEN_ENDPOINT_URI,
     caFile: CERT_STORE,
-    strictSSL: true
+    strictSSL: true,
+    timeout: 5000,
   }, opts);
 
   // check for the different auth strategies
@@ -119,6 +120,7 @@ ClientBase.prototype._generateReqOptions = function(url, path, body, method, hea
     'strictSSL': this.strictSSL,
     'body': bodyStr,
     'method': method,
+    'timeout': this.timeout,
     'headers' : {
       'Content-Type'     : 'application/json',
       'Accept'           : 'application/json',
@@ -127,8 +129,8 @@ ClientBase.prototype._generateReqOptions = function(url, path, body, method, hea
   };
 
   options.headers = assign(options.headers, headers);
-    
-    
+
+
   // add additional headers when we're using the "api key" and "api secret"
   if (this.apiSecret && this.apiKey) {
     var sig = this._generateSignature(path, method, bodyStr);

--- a/test/testClient.js
+++ b/test/testClient.js
@@ -14,10 +14,17 @@ describe('Client', function() {
 
   describe('client constructor', function() {
     it('should return client', function() {
-      var client = new Client({'apiKey': 'mykey', 'apiSecret': 'mysecret', 'baseApiUri': na.TEST_BASE_URI});
+      var client = new Client({'apiKey': 'mykey', 'apiSecret': 'mysecret', 'baseApiUri': na.TEST_BASE_URI, 'timeout': 30000});
       assert(client);
       assert.equal(client.apiKey, 'mykey');
       assert.equal(client.apiSecret, 'mysecret');
+      assert.equal(client.timeout, 30000);
+    });
+    it('should has default option values', function() {
+        var client = new Client({'apiKey': 'mykey', 'apiSecret': 'mysecret'});
+        assert(client);
+        assert.equal(client.timeout, 5000);
+        assert.equal(client.baseApiUri, 'https://api.coinbase.com/v2/');
     });
     it('should require constructor new call', function(){
       var cl1 = Client({'apiKey': 'mykey', 'apiSecret': 'mysecret', 'baseApiUri': na.TEST_BASE_URI});


### PR DESCRIPTION
The `request` package does not implement a default timeout, meaning that network/API issues can cause requests to hang indefinitely, leading to callbacks never erroring / being called back.